### PR TITLE
Update Simple Form Denpendency Version

### DIFF
--- a/freya.gemspec
+++ b/freya.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_path = 'lib'
-  s.add_dependency 'simple_form', '~> 4.0'
+  s.add_dependency 'simple_form', '~> 5.1'
 end

--- a/freya.gemspec
+++ b/freya.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |s|
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_path = 'lib'
-  s.add_dependency 'simple_form', '~> 5.1'
+  s.add_dependency 'simple_form', '~> 5.2'
 end


### PR DESCRIPTION
This specific version of the simple_form gem is causing errors when trying to update ruby ​​to new versions.